### PR TITLE
Fix AttributeError: 'NoneType' object has no attribute 'role' when there is no focus object

### DIFF
--- a/addon/globalPlugins/enhancedControlSupport/__init__.py
+++ b/addon/globalPlugins/enhancedControlSupport/__init__.py
@@ -121,6 +121,8 @@ def shouldUseTimerMixin(conf, obj, clsList):
 	return(False)
 def objectWithFocus():
 	realFocus = NVDAObject.objectWithFocus()
+	if realFocus is None:
+		return(realFocus)
 	if realFocus.role in [
 		controlTypes.Role.MENUBAR,
 		controlTypes.Role.MENU,


### PR DESCRIPTION
## Summary

`objectWithFocus()` reads `realFocus.role` immediately after `realFocus = NVDAObject.objectWithFocus()` without checking the result. When there is no current focus object, `NVDAObject.objectWithFocus()` returns `None`, so `.role` raises and aborts the whole `gainFocus` event chain.

## Traceback (NVDA 2026.2)

```
File "...\enhancedControlSupport\__init__.py", in event_gainFocus
  oldFocus = objectWithFocus()
File "...\enhancedControlSupport\__init__.py", in objectWithFocus
  if realFocus.role in [
AttributeError: 'NoneType' object has no attribute 'role'
```

Because this runs in a global `event_gainFocus` handler, the crash also breaks downstream add-ons' `gainFocus` handling whenever focus events fire with no focus object.

## Fix

Return early when `realFocus is None`. This preserves the function's existing contract (it already returns `realFocus`, which can legitimately be `None`), and NVDA core already tolerates a `None` focus object — it simply no longer raises.

## Testing
- `ast.parse` / `py_compile`: clean.
- Guarded path returns the same value the underlying API returns (`None`), so no behavior change beyond not crashing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
