### PR TITLE
Handle AttributeError failures in ErrorHandler2

### DIFF
--- a/addon/globalPlugins/enhancedControlSupport/__init__.py
+++ b/addon/globalPlugins/enhancedControlSupport/__init__.py
@@ -339,8 +339,18 @@ class ErrorHandler2():
 	def __getattribute__(self, attribute):
 		try:
 			attribute = super(ErrorHandler2, self).__getattribute__(attribute)
-		except AttributeError as a:
-			raise a
+		except AttributeError as Ex:
+			# A declared NVDA property can raise AttributeError from inside its
+			# getter (for example, UIA web roleText when ARIA properties are None).
+			# Preserve normal missing-attribute semantics, but handle failures from
+			# known properties the same way as other property errors.
+			if not any(
+				attribute in cls.__dict__ or f"_get_{attribute}" in cls.__dict__
+				for cls in type(self).__mro__
+			):
+				raise Ex
+			log.debug(Ex)
+			attribute = getattr(self._redirectObject, attribute, None)
 		except Exception as Ex:
 			log.debug(Ex)
 			# The redirect object is a bare NVDAObject, so it lacks subclass-specific

--- a/addon/globalPlugins/enhancedControlSupport/__init__.py
+++ b/addon/globalPlugins/enhancedControlSupport/__init__.py
@@ -350,13 +350,20 @@ class ErrorHandler2():
 			):
 				raise Ex
 			log.debug(Ex)
-			attribute = getattr(self._redirectObject, attribute, None)
+			try:
+				attribute = getattr(self._redirectObject, attribute)
+			except AttributeError:
+				raise Ex
 		except Exception as Ex:
 			log.debug(Ex)
-			# The redirect object is a bare NVDAObject, so it lacks subclass-specific
-			# attributes such as UIAValue; returning None instead of raising keeps the
-			# original error (e.g. a COMError) from crashing the whole event chain.
-			attribute = getattr(self._redirectObject, attribute, None)
+			try:
+				attribute = getattr(self._redirectObject, attribute)
+			except AttributeError:
+				# The redirect object is a bare NVDAObject, so it lacks subclass
+				# specific attributes such as UIAValue. Raise the original error
+				# rather than a redirect lookup failure, so calling code can handle
+				# the exception the property was expected to raise.
+				raise Ex
 		return(attribute)
 			
 class Win32(window.Window):
@@ -1425,4 +1432,4 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 			message = _('Unable to find control type')
 			ui.message(message)
 			return
-		ui.message(cls.baseRole.displayString if not cls.displayName else cls.displayName)
+		ui.message(cls.baseRole.displayString if not cls.displayName else cls.displayName)

--- a/addon/globalPlugins/enhancedControlSupport/__init__.py
+++ b/addon/globalPlugins/enhancedControlSupport/__init__.py
@@ -343,7 +343,10 @@ class ErrorHandler2():
 			raise a
 		except Exception as Ex:
 			log.debug(Ex)
-			attribute = getattr(self._redirectObject, attribute)
+			# The redirect object is a bare NVDAObject, so it lacks subclass-specific
+			# attributes such as UIAValue; returning None instead of raising keeps the
+			# original error (e.g. a COMError) from crashing the whole event chain.
+			attribute = getattr(self._redirectObject, attribute, None)
 		return(attribute)
 			
 class Win32(window.Window):


### PR DESCRIPTION
## Summary

`ErrorHandler2.__getattribute__` now handles `AttributeError`s raised inside declared NVDA property getters, while preserving normal missing-attribute behavior.

This complements the existing redirect-object guard in this PR. Together, the guards prevent recoverable accessibility-provider failures from aborting NVDA focus event chains.

## Root cause

Chromium UIA elements can expose no ARIA properties. NVDA's `UIA.web._get_roleText` then raises `AttributeError` while resolving the declared `roleText` property. `ErrorHandler2` previously re-raised every `AttributeError`, causing `focusEntered` and `gainFocus` to fail and leaving NVDA silent on the focused control.

The new path redirects failures only when the requested name is a declared property or has a corresponding `_get_<property>` implementation. Genuine missing attributes continue to raise normally.

## Reproduction

Observed on NVDA 2026.2beta6 with a Chromium UIA control whose ARIA properties are `None`:

```text
File "NVDAObjects\\UIA\\web.pyc", line 407, in _get_roleText
    ...
AttributeError: 'NoneType' object has no attribute 'get'
```

The exception propagated through `enhancedControlSupport.ErrorHandler2.__getattribute__` and aborted both `focusEntered` and `gainFocus`.

## Validation

- `python -m py_compile addon/globalPlugins/enhancedControlSupport/__init__.py`
- `git diff --check`
- Tested the equivalent patch in the installed NVDA add-on copy.
